### PR TITLE
Added option to order logs by timestamps. Saves 20% allocations by the serializer when set to false. Option true by default to avoid breaking changes on Loki v2.3 and below. You are advised to set option to false when using Loki v2.4+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Under .NET Core, [remember to register](https://github.com/nlog/nlog/wiki/Regist
       endpoint="http://localhost:3100"
       username="myusername"
       password="secret"
+      orderWrites="true"
       layout="${level}|${message}${onexception:|${exception:format=type,message,method:maxInnerExceptionLevel=5:innerFormat=shortType,message,method}}|source=${logger}">
       <!-- Loki requires at least one label associated with the log stream. 
       Make sure you specify at least one label here. -->
@@ -60,6 +61,8 @@ Under .NET Core, [remember to register](https://github.com/nlog/nlog/wiki/Regist
 `endpoint` must resolve to a fully-qualified absolute URL of the Loki Server when running in a [Single Proccess Mode](https://grafana.com/docs/loki/latest/overview/#modes-of-operation) or of the Loki Distributor when running in [Microservices Mode](https://grafana.com/docs/loki/latest/overview/#distributor).
 
 `username` and `password` are optional fields, used for basic authentication with Loki.
+
+`orderWrites` - Orders the logs by timestamp before sending them to loki when logs are batched in a single HTTP call. This is required if you use Loki v2.3 or below. But it is not required if you use Loki v2.4 or above (see [out-of-order writes](https://grafana.com/docs/loki/next/configuration/#accept-out-of-order-writes)). You are strongly advised to set this value to `false` when using Loki v2.4+ since it reduces allocations by about 20% by the serializer (default `true`).
 
 `label` elements can be used to enrich messages with additional [labels](https://grafana.com/docs/loki/latest/design-documents/labels/). `label/@layout` support usual NLog layout renderers.
 

--- a/src/Benchmark/LokiEventsSerializer.cs
+++ b/src/Benchmark/LokiEventsSerializer.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using NLog.Loki.Model;
+
+namespace Benchmark;
+
+[MemoryDiagnoser]
+public class LokiEventsSerializer
+{
+    private readonly MemoryStream stream = new();
+    private readonly JsonSerializerOptions serializerOptions = new();
+
+    private readonly LokiEvent @event;
+    private readonly IEnumerable<LokiEvent> manyLokiEvents;
+
+    public LokiEventsSerializer()
+    {
+        @event = new LokiEvent(
+            new LokiLabels(new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync")),
+            DateTime.Now,
+            "Info|Receive message from \"A\" with destination \"B\".");
+        var events = new List<LokiEvent>(100);
+        for(var i = 0; i < 100; i++)
+            events.Add(new LokiEvent(@event.Labels, DateTime.Now, @event.Line));
+        manyLokiEvents = events;
+
+        serializerOptions = new JsonSerializerOptions();
+        serializerOptions.Converters.Add(new NLog.Loki.LokiEventsSerializer());
+        serializerOptions.Converters.Add(new NLog.Loki.LokiEventSerializer());
+    }
+
+    [Benchmark]
+    public void SerializeManyEvents()
+    {
+        stream.Position = 0;
+        JsonSerializer.Serialize(stream, manyLokiEvents, serializerOptions);
+    }
+
+    [Benchmark]
+    public void SerializeSingleEvent()
+    {
+        stream.Position = 0;
+        JsonSerializer.Serialize(stream, @event, serializerOptions);
+    }
+}

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -12,8 +12,9 @@ namespace Benchmark
               .WithOptions(ConfigOptions.DisableLogFile);
 
             var summary = BenchmarkRunner.Run(new[]{
-                BenchmarkConverter.TypeToBenchmarks( typeof(Benchmarks), config),
-                BenchmarkConverter.TypeToBenchmarks( typeof(Transport), config),
+                //BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
+                //BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
+                BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
             });
         }
     }

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -12,8 +12,8 @@ namespace Benchmark
               .WithOptions(ConfigOptions.DisableLogFile);
 
             var summary = BenchmarkRunner.Run(new[]{
-                //BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
-                //BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
+                BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
+                BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
                 BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
             });
         }

--- a/src/Benchmark/Transport.cs
+++ b/src/Benchmark/Transport.cs
@@ -22,8 +22,8 @@ public class Transport
 
     public Transport()
     {
-        manyLokiEvents = new List<LokiEvent>(1000);
-        for(var i = 0; i < 1000; i++)
+        manyLokiEvents = new List<LokiEvent>(100);
+        for(var i = 0; i < 100; i++)
             manyLokiEvents.Add(new LokiEvent(lokiEvents[0].Labels, DateTime.Now, lokiEvents[0].Line));
     }
 

--- a/src/Benchmark/Transport.cs
+++ b/src/Benchmark/Transport.cs
@@ -18,7 +18,7 @@ public class Transport
             DateTime.Now,
             "Info|Receive message from \"A\" with destination \"B\".")};
     private readonly HttpLokiTransport transport = new(new LokiHttpClient(
-        new HttpClient { BaseAddress = new Uri("http://localhost:3100") }));
+        new HttpClient { BaseAddress = new Uri("http://localhost:3100") }), false);
 
     public Transport()
     {

--- a/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
+++ b/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
@@ -19,14 +19,14 @@ public class HttpLokiTransportTests
             new(new LokiLabels(new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1")),
                 date, "Info|Receive message from A with destination B."),
             new(new LokiLabels(new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1")),
-                date, "Info|Another event has occured here."),
+                date + TimeSpan.FromSeconds(2.2), "Info|Another event has occured here."),
             new(new LokiLabels(new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1")),
-                date, "Info|Event from another stream."),
+                date - TimeSpan.FromSeconds(0.9), "Info|Event from another stream."),
         };
     }
 
     [Test]
-    public async Task SerializeMessageToHttpLoki()
+    public async Task SerializeMessageToHttpLokiWithoutOrdering()
     {
         // Prepare the events to be sent to loki
         var events = CreateLokiEvents();
@@ -43,12 +43,39 @@ public class HttpLokiTransportTests
             });
 
         // Send the logging request
-        var transport = new HttpLokiTransport(httpClient.Object, false);
+        var transport = new HttpLokiTransport(httpClient.Object, orderWrites: false);
         await transport.WriteLogEventsAsync(events).ConfigureAwait(false);
 
         // Verify the json message format
         Assert.AreEqual(
-            "{\"streams\":[{\"stream\":{\"env\":\"unittest\",\"job\":\"Job1\"},\"values\":[[\"1640598506000000000\",\"Info|Receive message from A with destination B.\"],[\"1640598506000000000\",\"Info|Another event has occured here.\"],[\"1640598506000000000\",\"Info|Event from another stream.\"]]}]}",
+            "{\"streams\":[{\"stream\":{\"env\":\"unittest\",\"job\":\"Job1\"},\"values\":[[\"1640598506000000000\",\"Info|Receive message from A with destination B.\"],[\"1640598508200000000\",\"Info|Another event has occured here.\"],[\"1640598505100000000\",\"Info|Event from another stream.\"]]}]}",
+            serializedJsonMessage);
+    }
+
+    [Test]
+    public async Task SerializeMessageToHttpLokiWithOrdering()
+    {
+        // Prepare the events to be sent to loki
+        var events = CreateLokiEvents();
+
+        // Configure the ILokiHttpClient such that we intercept the JSON content and simulate an OK response from Loki.
+        string serializedJsonMessage = null;
+        var httpClient = new Mock<ILokiHttpClient>();
+        _ = httpClient.Setup(c => c.PostAsync("loki/api/v1/push", It.IsAny<HttpContent>()))
+            .Returns<string, HttpContent>(async (s, json) =>
+            {
+                // Intercept the json content so that we can verify it.
+                serializedJsonMessage = await json.ReadAsStringAsync().ConfigureAwait(false);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        // Send the logging request
+        var transport = new HttpLokiTransport(httpClient.Object, orderWrites: true);
+        await transport.WriteLogEventsAsync(events).ConfigureAwait(false);
+
+        // Verify the json message format
+        Assert.AreEqual(
+            "{\"streams\":[{\"stream\":{\"env\":\"unittest\",\"job\":\"Job1\"},\"values\":[[\"1640598505100000000\",\"Info|Event from another stream.\"],[\"1640598506000000000\",\"Info|Receive message from A with destination B.\"],[\"1640598508200000000\",\"Info|Another event has occured here.\"]]}]}",
             serializedJsonMessage);
     }
 
@@ -75,7 +102,7 @@ public class HttpLokiTransportTests
 
         // Verify the json message format
         Assert.AreEqual(
-                    "{\"streams\":[{\"stream\":{\"env\":\"unittest\",\"job\":\"Job1\"},\"values\":[[\"1640598506000000000\",\"Info|Event from another stream.\"]]}]}",
+                    "{\"streams\":[{\"stream\":{\"env\":\"unittest\",\"job\":\"Job1\"},\"values\":[[\"1640598505100000000\",\"Info|Event from another stream.\"]]}]}",
                     serializedJsonMessage);
     }
 

--- a/src/NLog.Loki.Tests/LokiTargetTests.cs
+++ b/src/NLog.Loki.Tests/LokiTargetTests.cs
@@ -113,7 +113,7 @@ namespace NLog.Loki.Tests
             Environment.SetEnvironmentVariable("HOST", "loki.lvh.me");
 
             var endpoint = Layout.FromString(endpointLayout);
-            var lokiTargetTransport = new LokiTarget().GetLokiTransport(endpoint, null, null);
+            var lokiTargetTransport = new LokiTarget().GetLokiTransport(endpoint, null, null, false);
 
             return lokiTargetTransport.GetType();
         }

--- a/src/NLog.Loki/LokiEventsSerializer.cs
+++ b/src/NLog.Loki/LokiEventsSerializer.cs
@@ -16,6 +16,13 @@ namespace NLog.Loki;
 /// </remarks>
 internal class LokiEventsSerializer : JsonConverter<IEnumerable<LokiEvent>>
 {
+    private readonly bool orderWrites;
+
+    public LokiEventsSerializer(bool orderWrites)
+    {
+        this.orderWrites = orderWrites;
+    }
+
     public override IEnumerable<LokiEvent> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         throw new NotSupportedException("This converter only supports serializing to JSON.");
@@ -42,9 +49,10 @@ internal class LokiEventsSerializer : JsonConverter<IEnumerable<LokiEvent>>
 
             writer.WriteStartArray("values");
 
-            // TODO: add option with out-of-order by default, but opt-in to enforce ordering
-            // https://grafana.com/docs/loki/latest/configuration/#accept-out-of-order-writes
-            foreach(var @event in stream/*.OrderBy(le => le.Timestamp)*/)
+            // Order logs by timestamp only if the option is opted-in, because it costs
+            // approximately 20% more allocation when serializing 100 events.
+            IEnumerable<LokiEvent> orderedStream = orderWrites ? stream.OrderBy(le => le.Timestamp) : stream;
+            foreach(var @event in orderedStream)
             {
                 writer.WriteStartArray();
                 var timestamp = UnixDateTimeConverter.ToUnixTimeNs(@event.Timestamp).ToString("g", CultureInfo.InvariantCulture);

--- a/src/NLog.Loki/LokiEventsSerializer.cs
+++ b/src/NLog.Loki/LokiEventsSerializer.cs
@@ -44,7 +44,7 @@ internal class LokiEventsSerializer : JsonConverter<IEnumerable<LokiEvent>>
 
             // TODO: add option with out-of-order by default, but opt-in to enforce ordering
             // https://grafana.com/docs/loki/latest/configuration/#accept-out-of-order-writes
-            foreach(var @event in stream.OrderBy(le => le.Timestamp))
+            foreach(var @event in stream/*.OrderBy(le => le.Timestamp)*/)
             {
                 writer.WriteStartArray();
                 var timestamp = UnixDateTimeConverter.ToUnixTimeNs(@event.Timestamp).ToString("g", CultureInfo.InvariantCulture);

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -25,6 +25,13 @@ namespace NLog.Loki
 
         public Layout Password { get; init; }
 
+        /// <summary>
+        /// Orders the logs by timestamp before sending them to Loki.
+        /// Required as <see langword="true"/> before Loki v2.4. Leave as <see langword="false"/> if you are running Loki v2.4 or above.
+        /// See <see href="https://grafana.com/docs/loki/latest/configuration/#accept-out-of-order-writes"/>.
+        /// </summary>
+        public bool OrderWrites { get; init; }
+
         [ArrayParameter(typeof(LokiTargetLabel), "label")]
         public IList<LokiTargetLabel> Labels { get; }
 
@@ -34,10 +41,9 @@ namespace NLog.Loki
         {
             Labels = new List<LokiTargetLabel>();
 
-            lazyLokiTransport =
-                new Lazy<ILokiTransport>(
-                    () => GetLokiTransport(Endpoint, Username, Password),
-                    LazyThreadSafetyMode.ExecutionAndPublication);
+            lazyLokiTransport = new Lazy<ILokiTransport>(
+                () => GetLokiTransport(Endpoint, Username, Password, OrderWrites),
+                LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
         protected override void Write(IList<AsyncLogEventInfo> logEvents)
@@ -65,10 +71,8 @@ namespace NLog.Loki
 
         private LokiEvent GetLokiEvent(LogEventInfo logEvent)
         {
-            var labels =
-                new LokiLabels(
-                    Labels.Select(
-                        ltl => new LokiLabel(ltl.Name, ltl.Layout.Render(logEvent))));
+            var labels = new LokiLabels(
+                Labels.Select(ltl => new LokiLabel(ltl.Name, ltl.Layout.Render(logEvent))));
 
             var line = RenderLogEvent(Layout, logEvent);
 
@@ -77,17 +81,19 @@ namespace NLog.Loki
             return @event;
         }
 
-        internal ILokiTransport GetLokiTransport(Layout endpoint, Layout username, Layout password)
+        internal ILokiTransport GetLokiTransport(
+            Layout endpoint, Layout username, Layout password, bool orderWrites)
         {
             var endpointUri = RenderLogEvent(endpoint, LogEventInfo.CreateNullEvent());
             var usr = RenderLogEvent(username, LogEventInfo.CreateNullEvent());
             var pwd = RenderLogEvent(password, LogEventInfo.CreateNullEvent());
+
             if(Uri.TryCreate(endpointUri, UriKind.Absolute, out var uri))
             {
                 if(uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
                 {
                     var lokiHttpClient = LokiHttpClientFactory(uri, usr, pwd);
-                    var httpLokiTransport = new HttpLokiTransport(lokiHttpClient);
+                    var httpLokiTransport = new HttpLokiTransport(lokiHttpClient, orderWrites);
 
                     return httpLokiTransport;
                 }

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -30,7 +30,7 @@ namespace NLog.Loki
         /// Required as <see langword="true"/> before Loki v2.4. Leave as <see langword="false"/> if you are running Loki v2.4 or above.
         /// See <see href="https://grafana.com/docs/loki/latest/configuration/#accept-out-of-order-writes"/>.
         /// </summary>
-        public bool OrderWrites { get; init; }
+        public bool OrderWrites { get; init; } = true;
 
         [ArrayParameter(typeof(LokiTargetLabel), "label")]
         public IList<LokiTargetLabel> Labels { get; }

--- a/src/Template/nlog.config
+++ b/src/Template/nlog.config
@@ -16,6 +16,7 @@
       taskDelayMilliseconds="500"
       endpoint="http://localhost:3100"
       retryCount="3"
+      orderWrites="true"
       layout="${level}|${message}${onexception:|${exception:format=type,message,method:maxInnerExceptionLevel=5:innerFormat=shortType,message,method}}|source=${logger}">
       <label name="app" layout="template" />
     </target>


### PR DESCRIPTION
Closes #2.

Added option to order logs by timestamps. Saves 20% allocations by the serializer when set to false. Option is true by default to avoid breaking changes.
See out-of-order writes feature with [Loki v2.4 release](https://github.com/grafana/loki/releases/tag/v2.4.0).

You are advised to set option to `false` to save allocations when using Loki v2.4+.

Added a benchmark to highlight cost of ordering events by timestamp.
Results for 100 ordered events:
- ordering: 11448 B allocated
- no ordering: 9176 B
So, 2.2kB for 100 events (already ordered) saved.

Added unit tests to cover with and without ordering the writes' serialization.