### PR TITLE
Added target to netstandard2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: |
+          6.0.x
+          3.1.x
     - name: Install Dependencies
       run: dotnet restore .\\src\\NLog.Loki.sln
     - name: Build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NuGet](https://img.shields.io/nuget/v/NLog.Targets.Loki)](https://www.nuget.org/packages/NLog.Targets.Loki)
 [![codecov](https://codecov.io/gh/corentinaltepe/nlog.loki/branch/master/graph/badge.svg?token=84N5XB4J09)](https://codecov.io/gh/corentinaltepe/nlog.loki)
 
-This is an [NLog](https://nlog-project.org/) target that sends messages to [Loki](https://grafana.com/oss/loki/) using Loki's HTTP Push API.
+This is an [NLog](https://nlog-project.org/) target that sends messages to [Loki](https://grafana.com/oss/loki/) using Loki's HTTP Push API. Available on .NET Standard 2.0 (.NET Core 2.0 and .NET Framework 4.6.1, above).
 
 > Loki is a horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus. It is designed to be very cost effective and easy to operate.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NLog Loki Target
 
 ![CI](https://github.com/corentinaltepe/nlog.loki/workflows/CI/badge.svg?branch=master)
-[![NuGet](https://img.shields.io/nuget/v/CorentinAltepe.NLog.Loki)](https://www.nuget.org/packages/CorentinAltepe.NLog.Loki)
+[![NuGet](https://img.shields.io/nuget/v/NLog.Targets.Loki)](https://www.nuget.org/packages/NLog.Targets.Loki)
 [![codecov](https://codecov.io/gh/corentinaltepe/nlog.loki/branch/master/graph/badge.svg?token=84N5XB4J09)](https://codecov.io/gh/corentinaltepe/nlog.loki)
 
 This is an [NLog](https://nlog-project.org/) target that sends messages to [Loki](https://grafana.com/oss/loki/) using Loki's HTTP Push API.
@@ -10,15 +10,15 @@ This is an [NLog](https://nlog-project.org/) target that sends messages to [Loki
 
 ## Installation
 
-The NLog.Loki NuGet package can be found [here](https://www.nuget.org/packages/CorentinAltepe.NLog.Loki). You can install it via one of the following commands below:
+The NLog.Loki NuGet package can be found [here](https://www.nuget.org/packages/NLog.Targets.Loki). You can install it via one of the following commands below:
 
 NuGet command:
 
-    Install-Package CorentinAltepe.NLog.Loki
+    Install-Package NLog.Targets.Loki
 
 .NET Core CLI command:
 
-    dotnet add package CorentinAltepe.NLog.Loki
+    dotnet add package NLog.Targets.Loki
 
 ## Usage
 

--- a/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
+++ b/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
@@ -136,6 +136,9 @@ public class HttpLokiTransportTests
         var transport = new HttpLokiTransport(httpClient.Object, false);
         var exception = Assert.ThrowsAsync<HttpRequestException>(() => transport.WriteLogEventsAsync(CreateLokiEvents()));
         Assert.AreEqual("Failed pushing logs to Loki.", exception.Message);
+        
+        #if NET6_0_OR_GREATER
         Assert.Null(exception.StatusCode);
+        #endif
     }
 }

--- a/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
+++ b/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
@@ -138,7 +138,7 @@ public class HttpLokiTransportTests
         Assert.AreEqual("Failed pushing logs to Loki.", exception.Message);
         
         #if NET6_0_OR_GREATER
-        Assert.Null(exception.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Conflict, exception.StatusCode);
         #endif
     }
 }

--- a/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
+++ b/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
@@ -136,6 +136,6 @@ public class HttpLokiTransportTests
         var transport = new HttpLokiTransport(httpClient.Object, false);
         var exception = Assert.ThrowsAsync<HttpRequestException>(() => transport.WriteLogEventsAsync(CreateLokiEvents()));
         Assert.AreEqual("Failed pushing logs to Loki.", exception.Message);
-        Assert.AreEqual(HttpStatusCode.Conflict, exception.StatusCode);
+        Assert.Null(exception.StatusCode);
     }
 }

--- a/src/NLog.Loki.Tests/NLog.Loki.Tests.csproj
+++ b/src/NLog.Loki.Tests/NLog.Loki.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFrameworks>net6.0;netcoreapp3.1;net480</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/NLog.Loki/HttpLokiTransport.cs
+++ b/src/NLog.Loki/HttpLokiTransport.cs
@@ -50,7 +50,12 @@ namespace NLog.Loki
 
             InternalLogger.Error("Failed pushing logs to Loki. Code: {Code}. Reason: {Reason}. Message: {Message}.",
                 response.StatusCode, response.ReasonPhrase, content);
-            throw new HttpRequestException("Failed pushing logs to Loki.");
+            
+            #if NET6_0_OR_GREATER
+                throw new HttpRequestException("Failed pushing logs to Loki.", inner: null, response.StatusCode);
+            #else
+                throw new HttpRequestException("Failed pushing logs to Loki.");
+            #endif
         }
     }
 }

--- a/src/NLog.Loki/HttpLokiTransport.cs
+++ b/src/NLog.Loki/HttpLokiTransport.cs
@@ -50,7 +50,7 @@ namespace NLog.Loki
 
             InternalLogger.Error("Failed pushing logs to Loki. Code: {Code}. Reason: {Reason}. Message: {Message}.",
                 response.StatusCode, response.ReasonPhrase, content);
-            throw new HttpRequestException("Failed pushing logs to Loki.", inner: null, response.StatusCode);
+            throw new HttpRequestException("Failed pushing logs to Loki.");
         }
     }
 }

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -19,18 +19,18 @@ namespace NLog.Loki
         private readonly Lazy<ILokiTransport> lazyLokiTransport;
 
         [RequiredParameter]
-        public Layout Endpoint { get; init; }
+        public Layout Endpoint { get; set; }
 
-        public Layout Username { get; init; }
+        public Layout Username { get; set; }
 
-        public Layout Password { get; init; }
+        public Layout Password { get; set; }
 
         /// <summary>
         /// Orders the logs by timestamp before sending them to Loki.
         /// Required as <see langword="true"/> before Loki v2.4. Leave as <see langword="false"/> if you are running Loki v2.4 or above.
         /// See <see href="https://grafana.com/docs/loki/latest/configuration/#accept-out-of-order-writes"/>.
         /// </summary>
-        public bool OrderWrites { get; init; } = true;
+        public bool OrderWrites { get; set; } = true;
 
         [ArrayParameter(typeof(LokiTargetLabel), "label")]
         public IList<LokiTargetLabel> Labels { get; }

--- a/src/NLog.Loki/NLog.Loki.csproj
+++ b/src/NLog.Loki/NLog.Loki.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <PackageId>NLog.Targets.Loki</PackageId>
     <Authors>Anton Gogolev, Corentin Altepe</Authors>
     <Company />
@@ -20,6 +21,10 @@
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.7.13" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLog.Loki/NLog.Loki.csproj
+++ b/src/NLog.Loki/NLog.Loki.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <PackageId>CorentinAltepe.NLog.Loki</PackageId>
+    <PackageId>NLog.Targets.Loki</PackageId>
     <Authors>Anton Gogolev, Corentin Altepe</Authors>
     <Company />
     <Product />


### PR DESCRIPTION
Fixes #15.

- [x] Target .netstandard2.0 in tests to verify appropriate behavior on multi-platforms. [See there](https://stackoverflow.com/a/44478400/2523877) how to do that.