### PR TITLE
Fixed target when run on NLog v5

### DIFF
--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -54,12 +54,6 @@ namespace NLog.Loki
             InitializeTarget();
         }
 
-        protected override void Write(IList<AsyncLogEventInfo> logEvents)
-        {
-            var events = GetLokiEvents(logEvents.Select(alei => alei.LogEvent));
-            _lazyLokiTransport.Value.WriteLogEventsAsync(events).ConfigureAwait(false).GetAwaiter().GetResult();
-        }
-
         protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
         {
             var @event = GetLokiEvent(logEvent);

--- a/src/Template/Template.csproj
+++ b/src/Template/Template.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NLog.Loki\NLog.Loki.csproj" />


### PR DESCRIPTION
Fixes #34.

I think the root cause was that the method AsyncTaskTarget.Write() became sealed in NLog v5, preventing the target from overriding the method. It was removed, and it seems to solve the issue.