### PR TITLE
Remove charset from Content-Type Header for better compatibility with older loki versions

### DIFF
--- a/src/NLog.Loki/HttpLokiTransport.cs
+++ b/src/NLog.Loki/HttpLokiTransport.cs
@@ -52,6 +52,10 @@ internal sealed class HttpLokiTransport : ILokiTransport
     {
         var jsonContent = JsonContent.Create(lokiEvent, options: _jsonOptions);
 
+        // Some old loki versions support only 'application/json',
+        // not 'application/json; charset=utf-8' content-Type header
+        jsonContent.Headers.ContentType.CharSet = string.Empty;
+
         // If no compression required
         if(_gzipLevel == CompressionLevel.NoCompression)
             return jsonContent;


### PR DESCRIPTION
Some old loki versions support only 'application/json',
not 'application/json; charset=utf-8' content-Type header.
It results in 400 (Bad request) loki response.

Issue example:
https://github.com/grafana/loki/issues/2329