### PR TITLE
Reduced allocations by 6.7% and CPU time by 7.9% when batching log events

### DIFF
--- a/src/Benchmark/LokiEventsSerializer.cs
+++ b/src/Benchmark/LokiEventsSerializer.cs
@@ -20,7 +20,7 @@ public class LokiEventsSerializer
     public LokiEventsSerializer()
     {
         @event = new LokiEvent(
-            new LokiLabels(new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync")),
+            new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
             DateTime.Now,
             "Info|Receive message from \"A\" with destination \"B\".");
         var events = new List<LokiEvent>(100);

--- a/src/Benchmark/LokiEventsSerializer.cs
+++ b/src/Benchmark/LokiEventsSerializer.cs
@@ -10,51 +10,51 @@ namespace Benchmark;
 [MemoryDiagnoser]
 public class LokiEventsSerializer
 {
-    private readonly MemoryStream stream = new();
-    private readonly JsonSerializerOptions serializerOptionsWithoutOrdering = new();
-    private readonly JsonSerializerOptions serializerOptionsWithOrdering = new();
+    private readonly MemoryStream _stream = new();
+    private readonly JsonSerializerOptions _serializerOptionsWithoutOrdering = new();
+    private readonly JsonSerializerOptions _serializerOptionsWithOrdering = new();
 
-    private readonly LokiEvent @event;
-    private readonly IEnumerable<LokiEvent> manyLokiEvents;
+    private readonly LokiEvent _event;
+    private readonly IEnumerable<LokiEvent> _manyLokiEvents;
 
     public LokiEventsSerializer()
     {
-        @event = new LokiEvent(
-            new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
+        _event = new LokiEvent(
+            new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
             DateTime.Now,
             "Info|Receive message from \"A\" with destination \"B\".");
         var events = new List<LokiEvent>(100);
         for(var i = 0; i < 100; i++)
-            events.Add(new LokiEvent(@event.Labels, DateTime.Now, @event.Line));
-        manyLokiEvents = events;
+            events.Add(new LokiEvent(_event.Labels, DateTime.Now, _event.Line));
+        _manyLokiEvents = events;
 
-        serializerOptionsWithoutOrdering = new JsonSerializerOptions();
-        serializerOptionsWithoutOrdering.Converters.Add(new NLog.Loki.LokiEventsSerializer(orderWrites: false));
-        serializerOptionsWithoutOrdering.Converters.Add(new NLog.Loki.LokiEventSerializer());
+        _serializerOptionsWithoutOrdering = new JsonSerializerOptions();
+        _serializerOptionsWithoutOrdering.Converters.Add(new NLog.Loki.LokiEventsSerializer(orderWrites: false));
+        _serializerOptionsWithoutOrdering.Converters.Add(new NLog.Loki.LokiEventSerializer());
 
-        serializerOptionsWithOrdering = new JsonSerializerOptions();
-        serializerOptionsWithOrdering.Converters.Add(new NLog.Loki.LokiEventsSerializer(orderWrites: true));
-        serializerOptionsWithOrdering.Converters.Add(new NLog.Loki.LokiEventSerializer());
+        _serializerOptionsWithOrdering = new JsonSerializerOptions();
+        _serializerOptionsWithOrdering.Converters.Add(new NLog.Loki.LokiEventsSerializer(orderWrites: true));
+        _serializerOptionsWithOrdering.Converters.Add(new NLog.Loki.LokiEventSerializer());
     }
 
     [Benchmark]
     public void SerializeManyEventsWithoutOrdering()
     {
-        stream.Position = 0;
-        JsonSerializer.Serialize(stream, manyLokiEvents, serializerOptionsWithoutOrdering);
+        _stream.Position = 0;
+        JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithoutOrdering);
     }
 
     [Benchmark]
     public void SerializeManyEventsWithOrdering()
     {
-        stream.Position = 0;
-        JsonSerializer.Serialize(stream, manyLokiEvents, serializerOptionsWithOrdering);
+        _stream.Position = 0;
+        JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithOrdering);
     }
 
     [Benchmark]
     public void SerializeSingleEvent()
     {
-        stream.Position = 0;
-        JsonSerializer.Serialize(stream, @event, serializerOptionsWithoutOrdering);
+        _stream.Position = 0;
+        JsonSerializer.Serialize(_stream, _event, _serializerOptionsWithoutOrdering);
     }
 }

--- a/src/Benchmark/LokiEventsSerializer.cs
+++ b/src/Benchmark/LokiEventsSerializer.cs
@@ -53,17 +53,17 @@ public class LokiEventsSerializer
         JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithoutOrdering);
     }
 
-    //[Benchmark]
-    //public void SerializeManyEventsWithOrdering()
-    //{
-    //    _stream.Position = 0;
-    //    JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithOrdering);
-    //}
+    [Benchmark]
+    public void SerializeManyEventsWithOrdering()
+    {
+        _stream.Position = 0;
+        JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithOrdering);
+    }
 
-    //[Benchmark]
-    //public void SerializeSingleEvent()
-    //{
-    //    _stream.Position = 0;
-    //    JsonSerializer.Serialize(_stream, _event, _serializerOptionsWithoutOrdering);
-    //}
+    [Benchmark]
+    public void SerializeSingleEvent()
+    {
+        _stream.Position = 0;
+        JsonSerializer.Serialize(_stream, _event, _serializerOptionsWithoutOrdering);
+    }
 }

--- a/src/Benchmark/LokiEventsSerializer.cs
+++ b/src/Benchmark/LokiEventsSerializer.cs
@@ -15,7 +15,7 @@ public class LokiEventsSerializer
     private readonly JsonSerializerOptions _serializerOptionsWithOrdering = new();
 
     private readonly LokiEvent _event;
-    private readonly IEnumerable<LokiEvent> _manyLokiEvents;
+    private IEnumerable<LokiEvent> _manyLokiEvents;
 
     public LokiEventsSerializer()
     {
@@ -23,10 +23,7 @@ public class LokiEventsSerializer
             new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
             DateTime.Now,
             "Info|Receive message from \"A\" with destination \"B\".");
-        var events = new List<LokiEvent>(100);
-        for(var i = 0; i < 100; i++)
-            events.Add(new LokiEvent(_event.Labels, DateTime.Now, _event.Line));
-        _manyLokiEvents = events;
+
 
         _serializerOptionsWithoutOrdering = new JsonSerializerOptions();
         _serializerOptionsWithoutOrdering.Converters.Add(new NLog.Loki.LokiEventsSerializer(orderWrites: false));
@@ -37,6 +34,18 @@ public class LokiEventsSerializer
         _serializerOptionsWithOrdering.Converters.Add(new NLog.Loki.LokiEventSerializer());
     }
 
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var events = new List<LokiEvent>(N);
+        for(var i = 0; i < N; i++)
+            events.Add(new LokiEvent(_event.Labels, DateTime.Now, _event.Line));
+        _manyLokiEvents = events;
+    }
+
+    [Params(/*1, 10,*/ 100, 1000)]
+    public int N { get; set; }
+
     [Benchmark]
     public void SerializeManyEventsWithoutOrdering()
     {
@@ -44,17 +53,17 @@ public class LokiEventsSerializer
         JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithoutOrdering);
     }
 
-    [Benchmark]
-    public void SerializeManyEventsWithOrdering()
-    {
-        _stream.Position = 0;
-        JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithOrdering);
-    }
+    //[Benchmark]
+    //public void SerializeManyEventsWithOrdering()
+    //{
+    //    _stream.Position = 0;
+    //    JsonSerializer.Serialize(_stream, _manyLokiEvents, _serializerOptionsWithOrdering);
+    //}
 
-    [Benchmark]
-    public void SerializeSingleEvent()
-    {
-        _stream.Position = 0;
-        JsonSerializer.Serialize(_stream, _event, _serializerOptionsWithoutOrdering);
-    }
+    //[Benchmark]
+    //public void SerializeSingleEvent()
+    //{
+    //    _stream.Position = 0;
+    //    JsonSerializer.Serialize(_stream, _event, _serializerOptionsWithoutOrdering);
+    //}
 }

--- a/src/Benchmark/LokiTargetBenchmark.cs
+++ b/src/Benchmark/LokiTargetBenchmark.cs
@@ -90,11 +90,11 @@ public class LokiTargetBenchmark
     }
 
     private static IEnumerable<LokiLabel> RenderAndMapLokiLabels(
-        IList<LokiTargetLabel> lokiTargetLabel,
+        IList<LokiTargetLabel> lokiTargetLabels,
         LogEventInfo logEvent)
     {
-        foreach(var lbl in lokiTargetLabel)
-            yield return new LokiLabel(lbl.Name, lbl.Layout.Render(logEvent));
+        foreach(var lokiTargetLabel in lokiTargetLabels)
+            yield return new LokiLabel(lokiTargetLabel.Name, lokiTargetLabel.Layout.Render(logEvent));
     }
 }
 

--- a/src/Benchmark/LokiTargetBenchmark.cs
+++ b/src/Benchmark/LokiTargetBenchmark.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using NLog;
+using NLog.Loki;
+using NLog.Loki.Model;
+
+namespace Benchmark;
+
+[MemoryDiagnoser]
+public class LokiTargetBenchmark
+{
+    private readonly LokiTarget _target = new();
+
+    private readonly IList<LokiTargetLabel> _labels = new List<LokiTargetLabel> {
+        new() { Name = "Label1", Layout = "MyLabel1Value" },
+        new() { Name = "Label2", Layout = "MyLabel2Value" },
+        new() { Name = "Label3", Layout = "MyLabel3Value" },
+    };
+
+    private List<LogEventInfo> _logs;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // Generate up to N messages for logevent infos
+        _logs = new(N);
+        for(var i = 0; i < N; i++)
+            _logs.Add(new LogEventInfo(LogLevel.Info, "MyLogger", RandomString(55)));
+    }
+
+    private static readonly Random Random = new();
+    public static string RandomString(int length)
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        return new string(Enumerable.Repeat(chars, length)
+            .Select(s => s[Random.Next(s.Length)]).ToArray());
+    }
+
+    [Params(1, 10, 100, 1000)]
+    public int N { get; set; }
+
+    [Benchmark]
+    public async Task WriteAsyncTaskList_Old()
+    {
+        var lokiEvents = GetLokiEvents(_logs);
+        using var jsonStreamContent = JsonContent.Create(lokiEvents);
+        _ = await jsonStreamContent.ReadAsByteArrayAsync();
+    }
+
+    private IEnumerable<LokiEvent> GetLokiEvents(IEnumerable<LogEventInfo> logEvents)
+    {
+        foreach(var e in logEvents)
+            yield return GetLokiEvent(e);
+    }
+
+    private LokiEvent GetLokiEvent(LogEventInfo logEvent)
+    {
+        var labels = new LokiLabels(_labels.Select(lbl => new LokiLabel(lbl.Name, lbl.Layout.Render(logEvent))));
+        return new LokiEvent(labels, logEvent.TimeStamp, logEvent.ToString());
+    }
+}
+

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -12,8 +12,8 @@ public class Program
           .WithOptions(ConfigOptions.DisableLogFile);
 
         var summary = BenchmarkRunner.Run(new[]{
-            BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
-            BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
+            //BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
+            //BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
             BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
             BenchmarkConverter.TypeToBenchmarks(typeof(LokiTargetBenchmark), config),
         });

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -12,9 +12,9 @@ public class Program
           .WithOptions(ConfigOptions.DisableLogFile);
 
         var summary = BenchmarkRunner.Run(new[]{
-            //BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
-            //BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
-            //BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
+            BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
+            BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
+            BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
             BenchmarkConverter.TypeToBenchmarks(typeof(LokiTargetBenchmark), config),
         });
     }

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -12,8 +12,8 @@ public class Program
           .WithOptions(ConfigOptions.DisableLogFile);
 
         var summary = BenchmarkRunner.Run(new[]{
-            //BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
-            //BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
+            BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
+            BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
             BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
             BenchmarkConverter.TypeToBenchmarks(typeof(LokiTargetBenchmark), config),
         });

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -12,9 +12,10 @@ public class Program
           .WithOptions(ConfigOptions.DisableLogFile);
 
         var summary = BenchmarkRunner.Run(new[]{
-            BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
-            BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
-            BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
+            //BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks), config),
+            //BenchmarkConverter.TypeToBenchmarks(typeof(Transport), config),
+            //BenchmarkConverter.TypeToBenchmarks(typeof(LokiEventsSerializer), config),
+            BenchmarkConverter.TypeToBenchmarks(typeof(LokiTargetBenchmark), config),
         });
     }
 }

--- a/src/Benchmark/Transport.cs
+++ b/src/Benchmark/Transport.cs
@@ -22,7 +22,7 @@ public class Transport
     private readonly IList<LokiEvent> _manyLokiEvents;
     private readonly IList<LokiEvent> _lokiEvents = new List<LokiEvent> {
         new(
-            new LokiLabels(new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync")),
+            new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
             DateTime.Now,
             "Info|Receive message from \"A\" with destination \"B\".")};
 

--- a/src/Benchmark/Transport.cs
+++ b/src/Benchmark/Transport.cs
@@ -22,7 +22,7 @@ public class Transport
     private readonly IList<LokiEvent> _manyLokiEvents;
     private readonly IList<LokiEvent> _lokiEvents = new List<LokiEvent> {
         new(
-            new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
+            new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "benchmark"), new LokiLabel("job", "WriteLogEventsAsync") }),
             DateTime.Now,
             "Info|Receive message from \"A\" with destination \"B\".")};
 

--- a/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
+++ b/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
@@ -20,11 +20,11 @@ public class HttpLokiTransportTests
         var date = new DateTime(2021, 12, 27, 9, 48, 26, DateTimeKind.Utc);
         for(var i = 0; i < numberEvents; i++)
         {
-            yield return new(new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date, "Info|Receive message from A with destination B.");
+            yield return new(new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date, "Info|Receive message from A with destination B.");
             i++;
-            yield return new(new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date + TimeSpan.FromSeconds(2.2), "Info|Another event has occured here.");
+            yield return new(new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date + TimeSpan.FromSeconds(2.2), "Info|Another event has occured here.");
             i++;
-            yield return new(new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date - TimeSpan.FromSeconds(0.9), "Info|Event from another stream.");
+            yield return new(new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date - TimeSpan.FromSeconds(0.9), "Info|Event from another stream.");
         }
     }
 

--- a/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
+++ b/src/NLog.Loki.Tests/HttpLokiTransportTests.cs
@@ -20,11 +20,11 @@ public class HttpLokiTransportTests
         var date = new DateTime(2021, 12, 27, 9, 48, 26, DateTimeKind.Utc);
         for(var i = 0; i < numberEvents; i++)
         {
-            yield return new(new LokiLabels(new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1")), date, "Info|Receive message from A with destination B.");
+            yield return new(new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date, "Info|Receive message from A with destination B.");
             i++;
-            yield return new(new LokiLabels(new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1")), date + TimeSpan.FromSeconds(2.2), "Info|Another event has occured here.");
+            yield return new(new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date + TimeSpan.FromSeconds(2.2), "Info|Another event has occured here.");
             i++;
-            yield return new(new LokiLabels(new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1")), date - TimeSpan.FromSeconds(0.9), "Info|Event from another stream.");
+            yield return new(new LokiLabels(new List<LokiLabel> { new LokiLabel("env", "unittest"), new LokiLabel("job", "Job1") }), date - TimeSpan.FromSeconds(0.9), "Info|Event from another stream.");
         }
     }
 

--- a/src/NLog.Loki.Tests/Model/LokiLabelsTests.cs
+++ b/src/NLog.Loki.Tests/Model/LokiLabelsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using NLog.Loki.Model;
 using NUnit.Framework;
@@ -19,35 +18,35 @@ internal class LokiLabelsTests
     {
         yield return
             new TestCaseData(
-                new LokiLabels(Array.Empty<LokiLabel>()),
-                new LokiLabels(Array.Empty<LokiLabel>())).
+                new LokiLabels(new HashSet<LokiLabel>()),
+                new LokiLabels(new HashSet<LokiLabel>())).
                 Returns(true);
 
         yield return
             new TestCaseData(
-                new LokiLabels(new[] { new LokiLabel("env", "dev") }),
-                new LokiLabels(Array.Empty<LokiLabel>())).
+                new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "dev") }),
+                new LokiLabels(new HashSet<LokiLabel>())).
                 Returns(false);
 
         yield return
             new TestCaseData(
-                new LokiLabels(new[] { new LokiLabel("env", "dev") }),
-                new LokiLabels(new[] { new LokiLabel("env", "dev") })).
+                new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "dev") }),
+                new LokiLabels(new HashSet<LokiLabel> { new LokiLabel("env", "dev") })).
                 Returns(true);
 
         yield return
             new TestCaseData(
-                    new LokiLabels(new List<LokiLabel> {
+                    new LokiLabels(new HashSet<LokiLabel> {
                         new LokiLabel("env", "dev"), new LokiLabel("level", "fatal") }),
-                    new LokiLabels(new List<LokiLabel> {
+                    new LokiLabels(new HashSet<LokiLabel> {
                         new LokiLabel("level", "fatal"), new LokiLabel("env", "dev") })).
                 Returns(true);
 
         yield return
             new TestCaseData(
-                    new LokiLabels(new List<LokiLabel> {
+                    new LokiLabels(new HashSet<LokiLabel> {
                         new LokiLabel("env", "dev"), new LokiLabel("level", "fatal") }),
-                    new LokiLabels(new List<LokiLabel> {
+                    new LokiLabels(new HashSet<LokiLabel> {
                         new LokiLabel("level", "fatal"), new LokiLabel("env", "dev"), new LokiLabel("severity", "debug") })).
                 Returns(false);
     }

--- a/src/NLog.Loki.Tests/Model/LokiLabelsTests.cs
+++ b/src/NLog.Loki.Tests/Model/LokiLabelsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NLog.Loki.Model;
 using NUnit.Framework;
@@ -18,36 +19,36 @@ internal class LokiLabelsTests
     {
         yield return
             new TestCaseData(
-                new LokiLabels(),
-                new LokiLabels()).
+                new LokiLabels(Array.Empty<LokiLabel>()),
+                new LokiLabels(Array.Empty<LokiLabel>())).
                 Returns(true);
 
         yield return
             new TestCaseData(
-                new LokiLabels(new LokiLabel("env", "dev")),
-                new LokiLabels()).
+                new LokiLabels(new[] { new LokiLabel("env", "dev") }),
+                new LokiLabels(Array.Empty<LokiLabel>())).
                 Returns(false);
 
         yield return
             new TestCaseData(
-                new LokiLabels(new LokiLabel("env", "dev")),
-                new LokiLabels(new LokiLabel("env", "dev"))).
+                new LokiLabels(new[] { new LokiLabel("env", "dev") }),
+                new LokiLabels(new[] { new LokiLabel("env", "dev") })).
                 Returns(true);
 
         yield return
             new TestCaseData(
-                    new LokiLabels(
-                        new LokiLabel("env", "dev"), new LokiLabel("level", "fatal")),
-                    new LokiLabels(
-                        new LokiLabel("level", "fatal"), new LokiLabel("env", "dev"))).
+                    new LokiLabels(new List<LokiLabel> {
+                        new LokiLabel("env", "dev"), new LokiLabel("level", "fatal") }),
+                    new LokiLabels(new List<LokiLabel> {
+                        new LokiLabel("level", "fatal"), new LokiLabel("env", "dev") })).
                 Returns(true);
 
         yield return
             new TestCaseData(
-                    new LokiLabels(
-                        new LokiLabel("env", "dev"), new LokiLabel("level", "fatal")),
-                    new LokiLabels(
-                        new LokiLabel("level", "fatal"), new LokiLabel("env", "dev"), new LokiLabel("severity", "debug"))).
+                    new LokiLabels(new List<LokiLabel> {
+                        new LokiLabel("env", "dev"), new LokiLabel("level", "fatal") }),
+                    new LokiLabels(new List<LokiLabel> {
+                        new LokiLabel("level", "fatal"), new LokiLabel("env", "dev"), new LokiLabel("severity", "debug") })).
                 Returns(false);
     }
 }

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
-using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -75,8 +74,16 @@ public class LokiTarget : AsyncTaskTarget
 
     private LokiEvent GetLokiEvent(LogEventInfo logEvent)
     {
-        var labels = new LokiLabels(Labels.Select(lbl => new LokiLabel(lbl.Name, lbl.Layout.Render(logEvent))));
+        var labels = new LokiLabels(RenderAndMapLokiLabels(Labels, logEvent));
         return new LokiEvent(labels, logEvent.TimeStamp, RenderLogEvent(Layout, logEvent));
+    }
+
+    private static IEnumerable<LokiLabel> RenderAndMapLokiLabels(
+        IList<LokiTargetLabel> lokiTargetLabel,
+        LogEventInfo logEvent)
+    {
+        foreach(var lbl in lokiTargetLabel)
+            yield return new LokiLabel(lbl.Name, lbl.Layout.Render(logEvent));
     }
 
     internal ILokiTransport GetLokiTransport(

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -78,12 +78,14 @@ public class LokiTarget : AsyncTaskTarget
         return new LokiEvent(labels, logEvent.TimeStamp, RenderLogEvent(Layout, logEvent));
     }
 
-    private static IEnumerable<LokiLabel> RenderAndMapLokiLabels(
-        IList<LokiTargetLabel> lokiTargetLabel,
+    private static ISet<LokiLabel> RenderAndMapLokiLabels(
+        IList<LokiTargetLabel> lokiTargetLabels,
         LogEventInfo logEvent)
     {
-        foreach(var lbl in lokiTargetLabel)
-            yield return new LokiLabel(lbl.Name, lbl.Layout.Render(logEvent));
+        var set = new HashSet<LokiLabel>();
+        for(var i = 0; i < lokiTargetLabels.Count; i++)
+            _ = set.Add(new LokiLabel(lokiTargetLabels[i].Name, lokiTargetLabels[i].Layout.Render(logEvent)));
+        return set;
     }
 
     internal ILokiTransport GetLokiTransport(

--- a/src/NLog.Loki/Model/LokiLabel.cs
+++ b/src/NLog.Loki/Model/LokiLabel.cs
@@ -29,7 +29,7 @@ internal class LokiLabel : IEquatable<LokiLabel>
             return false;
         if(ReferenceEquals(this, other))
             return true;
-        if(other.GetType() != this.GetType())
+        if(other.GetType() != GetType())
             return false;
         return Equals((LokiLabel)other);
     }

--- a/src/NLog.Loki/Model/LokiLabels.cs
+++ b/src/NLog.Loki/Model/LokiLabels.cs
@@ -10,8 +10,6 @@ internal class LokiLabels : IEquatable<LokiLabels>
 
     public ISet<LokiLabel> Labels { get; }
 
-    public LokiLabels(params LokiLabel[] labels) : this((IEnumerable<LokiLabel>)labels) { }
-
     public LokiLabels(IEnumerable<LokiLabel> labels)
     {
         Labels = new HashSet<LokiLabel>(labels ?? Enumerable.Empty<LokiLabel>());

--- a/src/NLog.Loki/Model/LokiLabels.cs
+++ b/src/NLog.Loki/Model/LokiLabels.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace NLog.Loki.Model;
 
@@ -10,13 +9,15 @@ internal class LokiLabels : IEquatable<LokiLabels>
 
     public ISet<LokiLabel> Labels { get; }
 
-    public LokiLabels(IEnumerable<LokiLabel> labels)
+    public LokiLabels(ISet<LokiLabel> labels)
     {
-        Labels = new HashSet<LokiLabel>(labels ?? Enumerable.Empty<LokiLabel>());
-
+        Labels = labels;
         unchecked
         {
-            _hashCode = Labels.Aggregate(0, (current, label) => (current * 397) ^ label.GetHashCode());
+            var hash = 0;
+            foreach(var label in labels)
+                hash = (hash * 397) ^ label.GetHashCode();
+            _hashCode = hash;
         }
     }
 


### PR DESCRIPTION
Added a benchmark to play with code optimization. It was already quite well optimized, I only removed a linq .Select() call, reducing allocations by approximately 2% when batching log events.

There must be a way to reduce allocation, if it were possible to hash the labels sets for all log lines before allocating, and apply the group by only for hashes not already as a group. That's be complex to implement so I'll stop here.