### PR TITLE
Upgraded to NLog v5.2.2, changed default values to `compressionLevel`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Under .NET Core, [remember to register](https://github.com/nlog/nlog/wiki/Regist
 
 `username` and `password` are optional fields, used for basic authentication with Loki.
 
-`orderWrites` - Orders the logs by timestamp before sending them to loki when logs are batched in a single HTTP call. This is required if you use Loki v2.3 or lower. But it is not required if you use Loki v2.4 or higher (see [out-of-order writes](https://grafana.com/docs/loki/next/configuration/#accept-out-of-order-writes)). You are strongly advised to set this value to `false` when using Loki v2.4+ since it reduces allocations by about 20% by the serializer (default `true`).
+`orderWrites` - Orders the logs by timestamp before sending them to loki when logs are batched in a single HTTP call. This is required if you use Loki v2.3 or lower. But it is not required if you use Loki v2.4 or higher (see [out-of-order writes](https://grafana.com/docs/loki/next/configuration/#accept-out-of-order-writes)). You are strongly advised to set this value to `false` when using Loki v2.4+ since it reduces allocations by about 20% by the serializer (default `false`).
 
-`compressionLevel` - Gzip compression level applied if any when sending messages to Loki (default `noCompression`). Possible values:
+`compressionLevel` - Gzip compression level applied if any when sending messages to Loki (default `optimal`). Possible values:
 
 - `noCompression`: no compression applied, HTTP header will not specify a Content-Encoding with gzip value.
 - `fastest`: the compression operation should complete as quickly as possible, even if the resulting file is not optimally compressed.
@@ -99,6 +99,19 @@ Under .NET Core, [remember to register](https://github.com/nlog/nlog/wiki/Regist
 `queueLimit` - Gets or sets the limit on the number of requests in the lazy writer thread request queue (default 10000).
 
 `overflowAction` - Gets or sets the action to be taken when the lazy writer thread request queue count exceeds the set limit (default Discard).
+
+### Upgrading From v1 To v2
+
+The v2 of the library applies _better_ default values for common usage. Check your current configuration and compare it against the breaking
+changes below to adapt to your use case.
+
+#### Breaking Changes
+
+- `compressionLevel` set to `optimal` by default, instead of `noCompression`. If you are certain you do no want compression,
+  specify the value as `noCompression` in your configuration.
+- `orderWrites` set to `false` by default. Set it to `true` only if you run on Loki v2.3 or lower, or if your logs come largely unordered
+  and need to be reordered for Loki to process them.
+- Dropped support for NLog v4, upgraded to NLog v5.
 
 ### Benchmark
 

--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
-    <PackageReference Include="NLog" Version="5.0.0" />
+    <PackageReference Include="NLog" Version="5.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NLog.Loki\NLog.Loki.csproj" />

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -27,17 +27,17 @@ public class LokiTarget : AsyncTaskTarget
     public Layout Password { get; set; }
 
     /// <summary>
-    /// Orders the logs by timestamp before sending them to Loki.
-    /// Required as <see langword="true"/> before Loki v2.4. Leave as <see langword="false"/> if you are running Loki v2.4 or above.
+    /// Orders the logs by timestamp before sending them to Loki. False by default.
+    /// Required as <see langword="true"/> before Loki v2.4. Leave as <see langword="false"/> if you are running Loki v2.4 or higher.
     /// See <see href="https://grafana.com/docs/loki/latest/configuration/#accept-out-of-order-writes"/>.
     /// </summary>
-    public bool OrderWrites { get; set; } = true;
+    public bool OrderWrites { get; set; } = false;
 
     /// <summary>
     /// Defines if the HTTP messages sent to Loki must be gzip compressed, and with which compression level.
-    /// Possible values: NoCompression (default), Optimal, Fastest and SmallestSize (.NET 6 support only).
+    /// Possible values: NoCompression, Optimal (default), Fastest and SmallestSize (.NET 6 support only).
     /// </summary>
-    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.NoCompression;
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     public Layout ProxyUrl { get; set; }
     public Layout ProxyUser { get; set; }

--- a/src/NLog.Loki/NLog.Loki.csproj
+++ b/src/NLog.Loki/NLog.Loki.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Template/Template.csproj
+++ b/src/Template/Template.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.0.0" />
+    <PackageReference Include="NLog" Version="5.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NLog.Loki\NLog.Loki.csproj" />


### PR DESCRIPTION
### Upgrading From v1 To v2

The v2 of the library applies _better_ default values for common usage. Check your current configuration and compare it against the breaking changes below to adapt to your use case.

#### Breaking Changes

- `compressionLevel` set to `optimal` by default, instead of `noCompression`. If you are certain you do no want compression,
  specify the value as `noCompression` in your configuration.
- `orderWrites` set to `false` by default. Set it to `true` only if you run on Loki v2.3 or lower, or if your logs come largely unordered  and need to be reordered for Loki to process them.
- Dropped support for NLog v4, upgraded to NLog v5.