### PR TITLE
Attempt at adding support for .NET Framework 4.8

### DIFF
--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;

--- a/src/NLog.Loki/NLog.Loki.csproj
+++ b/src/NLog.Loki/NLog.Loki.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <PackageId>NLog.Targets.Loki</PackageId>
     <Authors>Anton Gogolev, Corentin Altepe</Authors>
@@ -27,7 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NLog" Version="5.2.8" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
This is only an idea of adding support for .NET Framework 4.8, following issue #114. This proof of concept is not ready to be merged.

* The added dependencies must be conditioned to only .NET Framework 4.8.
* The Json serliazing logic must be conditioned to .NET Framework 4.8 to avoid performance degradation for .NET 6+ users.
* Documentation and build, test, publish pipelines must be updated accordingly