### PR TITLE
Modifications to support passing X-Scope-OrgID http header for multi-tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Under .NET Core, [remember to register](https://github.com/nlog/nlog/wiki/Regist
       batchSize="200"
       taskDelayMilliseconds="500"
       endpoint="http://localhost:3100"
+      tenant="tenantid"
       username="myusername"
       password="secret"
       orderWrites="true"

--- a/src/NLog.Loki.Tests/LokiTargetTests.cs
+++ b/src/NLog.Loki.Tests/LokiTargetTests.cs
@@ -92,7 +92,7 @@ public class LokiTargetTests
         var endpoint = Layout.FromString(endpointLayout);
         using var target = new LokiTarget();
         using var lokiTargetTransport = target.GetLokiTransport(
-            endpoint, null, null, false,
+            endpoint, "1", null, null, false,
             "https://myproxy.com", "proxyDomain\\proxyUserA", "proxyPasswordA");
         return lokiTargetTransport.GetType();
     }


### PR DESCRIPTION
Modifications to support passing X-Scope-OrgID header for multi-tenancy.

Without this I was seeing failed push requests with an Unauthorized response. With this change my logs are now showing up in my test Loki system.