### PR TITLE
LokiLabel as readonly struct, and enumerate HashSet instead of ISet

### DIFF
--- a/src/Benchmark/LokiTargetBenchmark.cs
+++ b/src/Benchmark/LokiTargetBenchmark.cs
@@ -69,7 +69,7 @@ public class LokiTargetBenchmark
         return new LokiEvent(labels, logEvent.TimeStamp, logEvent.ToString());
     }
 
-    private static ISet<LokiLabel> RenderAndMapLokiLabels(
+    private static HashSet<LokiLabel> RenderAndMapLokiLabels(
         IList<LokiTargetLabel> lokiTargetLabels,
         LogEventInfo logEvent)
     {

--- a/src/NLog.Loki/LokiTarget.cs
+++ b/src/NLog.Loki/LokiTarget.cs
@@ -194,6 +194,8 @@ public class LokiTarget : AsyncTaskTarget
         string proxyUser,
         string proxyPassword)
     {
+        InternalLogger.Debug("LogiTarget: Creating HttpClient to Loki Endpoint: {0}", uri);
+
         // Configure handler for proxy settings
 #if NETSTANDARD || NETFRAMEWORK
         var handler = new HttpClientHandler();

--- a/src/NLog.Loki/Model/LokiLabel.cs
+++ b/src/NLog.Loki/Model/LokiLabel.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace NLog.Loki.Model;
 
-internal class LokiLabel : IEquatable<LokiLabel>
+internal readonly struct LokiLabel : IEquatable<LokiLabel>
 {
     public string Label { get; }
 
@@ -16,20 +16,12 @@ internal class LokiLabel : IEquatable<LokiLabel>
 
     public bool Equals(LokiLabel other)
     {
-        if(ReferenceEquals(null, other))
-            return false;
-        if(ReferenceEquals(this, other))
-            return true;
         return Label == other.Label && Value == other.Value;
     }
 
     public override bool Equals(object other)
     {
-        if(ReferenceEquals(null, other))
-            return false;
-        if(ReferenceEquals(this, other))
-            return true;
-        return Equals(other as LokiLabel);
+        return other is LokiLabel lokiLabel && Equals(lokiLabel);
     }
 
     public override int GetHashCode()

--- a/src/NLog.Loki/Model/LokiLabels.cs
+++ b/src/NLog.Loki/Model/LokiLabels.cs
@@ -7,9 +7,9 @@ internal class LokiLabels : IEquatable<LokiLabels>
 {
     private readonly int _hashCode;
 
-    public ISet<LokiLabel> Labels { get; }
+    public HashSet<LokiLabel> Labels { get; }
 
-    public LokiLabels(ISet<LokiLabel> labels)
+    public LokiLabels(HashSet<LokiLabel> labels)
     {
         Labels = labels;
         unchecked


### PR DESCRIPTION
I guess with NET10 then it will magically inline the concrete enumerator on the stack, when in the mood. But for everyone else then HashSet-struct-enumerator is faster.